### PR TITLE
Update keyword block_device to ebs_block_device

### DIFF
--- a/aws-cf-install.tf
+++ b/aws-cf-install.tf
@@ -77,7 +77,7 @@ resource "aws_instance" "bastion" {
   associate_public_ip_address = true
   security_groups = ["${module.vpc.aws_security_group_bastion_id}"]
   subnet_id = "${module.vpc.bastion_subnet}"
-  block_device {
+  ebs_block_device {
     device_name = "xvdc"
     volume_size = "40"
   }


### PR DESCRIPTION
Terraform 0.4.0 deprecates the block_device attribute of aws_instance replacing it with three more specific attributes to specify block device mappings: root_block_device, ebs_block_device, and ephemeral_block_device.

This change specifies ebs_block_device for the bastion aws instance.
